### PR TITLE
Allow AppVeyor to trigger builds on any branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@
 version: 1.0.{build}
 
 branches:
-  only:
-    - master
   except:
     - gh-pages
 


### PR DESCRIPTION
To align with Travis CI which doesn't have this limitation to build from master only.